### PR TITLE
Update 06-loading-ui-and-streaming.mdx

### DIFF
--- a/docs/02-app/01-building-your-application/01-routing/06-loading-ui-and-streaming.mdx
+++ b/docs/02-app/01-building-your-application/01-routing/06-loading-ui-and-streaming.mdx
@@ -56,6 +56,7 @@ In the same folder, `loading.js` will be nested inside `layout.js`. It will auto
 > - Navigation is immediate, even with [server-centric routing](/docs/app/building-your-application/routing/linking-and-navigating#how-routing-and-navigation-works).
 > - Navigation is interruptible, meaning changing routes does not need to wait for the content of the route to fully load before navigating to another route.
 > - Shared layouts remain interactive while new route segments load.
+> - Instant Loading States will override HTTP status codes set by other functions in server components (e.g. [`redirect`](https://nextjs.org/docs/app/api-reference/functions/redirect) and [`notFound`](https://nextjs.org/docs/app/api-reference/functions/not-found)) and return a HTTP 200 status code immediately
 
 > **Recommendation:** Use the `loading.js` convention for route segments (layouts and pages) as Next.js optimizes this functionality.
 


### PR DESCRIPTION
I'm attempting to describe behaviour seen when using a loading.js file for Instant Loading State together with a notFound or redirect function from next/navigation. 

The loading.js file will take precendence with its status code returning 200 immediately, while the other functions will only be able to change the final render and not HTTP codes as they usually would

<!-- Thanks for opening a PR! Your contribution is much appreciated.
To make sure your PR is handled as smoothly as possible we request that you follow the checklist sections below.
Choose the right checklist for the change(s) that you're making:

## For Contributors

### Improving Documentation

- Run `pnpm prettier-fix` to fix formatting issues before opening the PR.
- Read the Docs Contribution Guide to ensure your contribution follows the docs guidelines: https://nextjs.org/docs/community/contribution-guide

### Adding or Updating Examples

- The "examples guidelines" are followed from our contributing doc https://github.com/vercel/next.js/blob/canary/contributing/examples/adding-examples.md
- Make sure the linting passes by running `pnpm build && pnpm lint`. See https://github.com/vercel/next.js/blob/canary/contributing/repository/linting.md

### Fixing a bug

- Related issues linked using `fixes #number`
- Tests added. See: https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md

### Adding a feature

- Implements an existing feature request or RFC. Make sure the feature request has been accepted for implementation before opening a PR. (A discussion must be opened, see https://github.com/vercel/next.js/discussions/new?category=ideas)
- Related issues/discussions are linked using `fixes #number`
- e2e tests added (https://github.com/vercel/next.js/blob/canary/contributing/core/testing.md#writing-tests-for-nextjs
- Documentation added
- Telemetry added. In case of a feature if it's used or not.
- Errors have a helpful link attached, see https://github.com/vercel/next.js/blob/canary/contributing.md


## For Maintainers

- Minimal description (aim for explaining to someone not on the team to understand the PR)
- When linking to a Slack thread, you might want to share details of the conclusion
- Link both the Linear (Fixes NEXT-xxx) and the GitHub issues
- Add review comments if necessary to explain to the reviewer the logic behind a change

### What?

### Why?

### How?

Closes NEXT-
Fixes #

-->
